### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: '${{ github.workflow }}-${{ github.job }}-${{ github.head_ref || github.ref_name }}'
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/logibooks/logibooks.ext/security/code-scanning/4](https://github.com/logibooks/logibooks.ext/security/code-scanning/4)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/ci.yml` (after `on:` block is a common location) so all jobs inherit least-privilege defaults.  
Given the visible jobs, a safe minimal baseline is:

- `contents: read` (needed for checkout/read repo content)

This addresses the CodeQL finding without altering workflow behavior for read-only CI jobs. If the omitted `release` job needs elevated permissions, it should define a job-level `permissions` override there; since that code is not shown, we only apply the minimal explicit root permission now.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
